### PR TITLE
chore: update esbuild version

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) rectitude-open <open@rectitude.dev>
+Copyright (c) Rectitude Open <open@rectitude.dev>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Filament Ban Manager is a user-friendly plugin that provides complete ban management (both models and IPs) for your Filament panel, built on top of the [Banhammer](https://github.com/mchev/banhammer) package.
 
+This package is also a standalone part of a CMS project: [FilaPress](https://github.com/rectitude-open/filapress).
+
 ## Installation
 
 You can install the package via composer:

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "rectitude-open",
-            "email": "open@rectitude.dev",
+            "name": "Aspirant Zhang",
+            "email": "admin@aspirantzhang.com",
             "role": "Developer"
         }
     ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@tailwindcss/forms": "^0.5.4",
         "@tailwindcss/typography": "^0.5.9",
         "autoprefixer": "^10.4.14",
-        "esbuild": "^0.19.2",
+        "esbuild": "^0.25.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.26",
         "postcss-import": "^15.1.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified in the README that the Filament Ban Manager is also a standalone component of the FilaPress CMS, including a link to its GitHub repository.
  - Updated the license file to reflect the correct copyright holder.
- **Chores**
  - Updated author information in project metadata.
  - Upgraded the esbuild development dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->